### PR TITLE
为 `服务解散` 指令添加 `解散群组` 别名

### DIFF
--- a/nonebot_plugin_servicestate/__init__.py
+++ b/nonebot_plugin_servicestate/__init__.py
@@ -117,7 +117,7 @@ async def _(command_arg_list: List[str] = Depends(extract_str_list)):
     await service_group_matcher.finish(f"已成功合并 {len(bind_service_name_list)} 个服务")
 
 
-service_ungroup_matcher = on_command("服务解散", aliases={"解散服务"}, permission=SUPERUSER)
+service_ungroup_matcher = on_command("服务解散", aliases={"解散服务", "解散群组"}, permission=SUPERUSER)
 
 
 @service_ungroup_matcher.handle()


### PR DESCRIPTION
 这个 Pull Request 为 `服务解散` 指令添加了一个 `解散群组` 别名。

在 `README.md` 和插件元数据中，**解散群组**的用法为 `解散群组 <群组名称>`，但代码中并没有这个别名，可能会对用户造成误导，这个 Pull Request 把这个用法加入到了代码中。